### PR TITLE
feat: Handle more types of enrollment errors

### DIFF
--- a/fingwit.pot
+++ b/fingwit.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-19 13:24-0400\n"
+"POT-Creation-Date: 2025-08-26 17:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -104,14 +104,6 @@ msgstr ""
 
 #: fingwit:310
 msgid "This fingerprint is already saved, use a different finger."
-msgstr ""
-
-#: fingwit:315
-msgid "Sorry, this device cannot store any more fingerprints."
-msgstr ""
-
-#: fingwit:320
-msgid "Sorry, an unknown error occured."
 msgstr ""
 
 #: data/fingwit/fingwit.ui.h:1


### PR DESCRIPTION
Closes #24 
Closes #32
Closes #33 

This PR makes it so fingwit now properly handles enrollment errors that are either unknown or caused by a lack of storage space on the fingerprint reader.
For additional info on enrollment errors, see the fprint documentation: https://fprint.freedesktop.org/fprintd-dev/Device.html#enroll-statuses

<img width="800" alt="09-21 Sep 13 2025" src="https://github.com/user-attachments/assets/56731074-06d7-4b21-9ef7-1efe101960ff" />
