### PR TITLE
Update control: Added pkg-config to build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends: debhelper-compat (= 13),
                meson,
                libaudit-dev,
                libpam0g-dev,
+               pkg-config,
 Standards-Version: 3.9.6
 Rules-Requires-Root: no
 


### PR DESCRIPTION
Added pkg-config to build-depends

"Pkg-config binary missing from cross or native file, or env var undefined. Trying a default Pkg-config fallback at pkg-config Did not find pkg-config by name 'pkg-config'"